### PR TITLE
 取得系APIテストケースのサンプルコード追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ $ ./gradlew :sample-batch:bootRun -Pargs="--job=importStaffJob"
 | 接続先| URL|
 | :-----| :---------------------------------------|
 | 管理側画面| http://localhost:18081/admin|
-| 管理側API| http://localhost:18081/admin/api/v1/users.json|
+| 管理側API| http://localhost:18081/admin/api/v1/users|
 | フロント側| http://localhost:18080/|
 
 #### データベース接続先

--- a/sample-web-admin/src/test/groovy/com/sample/web/admin/controller/api/v1/user/UserRestControllerTest.groovy
+++ b/sample-web-admin/src/test/groovy/com/sample/web/admin/controller/api/v1/user/UserRestControllerTest.groovy
@@ -1,0 +1,81 @@
+package com.sample.web.admin.controller.html.home
+
+
+import org.hamcrest.Matchers
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.MediaType
+import org.springframework.security.test.context.support.WithMockUser
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.web.context.WebApplicationContext
+import spock.lang.Shared
+import spock.lang.Specification
+
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*
+import static org.springframework.test.web.servlet.setup.MockMvcBuilders.webAppContextSetup
+
+@SpringBootTest
+class UserRestControllerTest extends Specification {
+
+    @Autowired
+    WebApplicationContext wac
+
+    @Shared
+    MockMvc mvc
+
+    /**
+     * テストクラス内で一度きりの初期化
+     */
+    def setupSpec() {
+        // no-op
+    }
+
+    /**
+     * テストケースごとの初期化
+     */
+    def setup() {
+        mvc = webAppContextSetup(wac).apply(springSecurity()).build()
+    }
+
+    /**
+     * Case: ユーザ取得（複数）
+     */
+    @WithMockUser()
+    def "API_TEST_CASE: ユーザ取得（複数）"() {
+        /* Expected Response Data Sample
+            {
+              "data": [
+                {
+                  "id": 1,
+                  "first_name": "john",
+                  "last_name": "doe",
+                  "email": "test@sample.com",
+                  "tel": "09011112222",
+                  "zip": null,
+                  "address": "tokyo, chuo-ku 1-2-3"
+                }
+              ],
+              "message": "正常終了",
+              "page": 1,
+              "total_pages": 1
+            }
+         */
+        expect:
+        mvc.perform(get("/api/v1/users").contentType(MediaType.APPLICATION_JSON))
+        // 応答共通チェック
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8))
+        // 応答データ（共通）
+                .andExpect(jsonPath('$.message').value("正常終了"))
+                .andExpect(jsonPath('$.page').value(1))
+                .andExpect(jsonPath('$.total_pages').value(1))
+        // 応答データ（個別）
+                .andExpect(jsonPath('$.data').isArray())
+                .andExpect(jsonPath('$.data', Matchers.hasSize(1)))
+        // 応答データ（詳細）
+                .andExpect(jsonPath('$.data[0].id').value(1))
+                .andExpect(jsonPath('$.data[0].email').value("test@sample.com"))
+    }
+}

--- a/sample-web-admin/src/test/groovy/com/sample/web/admin/controller/api/v1/user/UserRestControllerTest.groovy
+++ b/sample-web-admin/src/test/groovy/com/sample/web/admin/controller/api/v1/user/UserRestControllerTest.groovy
@@ -1,6 +1,5 @@
 package com.sample.web.admin.controller.html.home
 
-
 import org.hamcrest.Matchers
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
@@ -17,6 +16,9 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*
 import static org.springframework.test.web.servlet.setup.MockMvcBuilders.webAppContextSetup
 
+/**
+ * ユーザAPIテストクラス
+ */
 @SpringBootTest
 class UserRestControllerTest extends Specification {
 
@@ -27,7 +29,12 @@ class UserRestControllerTest extends Specification {
     MockMvc mvc
 
     /**
-     * テストクラス内で一度きりの初期化
+     * APIルートパス
+     */
+    def String apiRoot = "/api/v1/users"
+
+    /**
+     * テストクラス全体の初期化
      */
     def setupSpec() {
         // no-op
@@ -43,8 +50,8 @@ class UserRestControllerTest extends Specification {
     /**
      * 応答情報コンソール出力
      */
-    def systemOutResponse(ResultActions resultActs) {
-        def content = resultActs.andReturn().getResponse().getContentAsString()
+    def systemOutResponse(ResultActions resultActions) {
+        def content = resultActions.andReturn().getResponse().getContentAsString()
         System.out.println("■応答データ:")
         System.out.println(content)
     }
@@ -55,7 +62,7 @@ class UserRestControllerTest extends Specification {
     @WithMockUser()
     def "API_TEST_CASE: ユーザ取得（複数）"() {
         setup:
-        def resultActions = mvc.perform(get("/api/v1/users").contentType(MediaType.APPLICATION_JSON))
+        def resultActions = mvc.perform(get(apiRoot).contentType(MediaType.APPLICATION_JSON))
         systemOutResponse(resultActions)
         /* Expected Response Data Sample
             {
@@ -86,7 +93,6 @@ class UserRestControllerTest extends Specification {
                 .andExpect(jsonPath('$.total_pages').value(1))
         // 応答データ（個別）
                 .andExpect(jsonPath('$.data').isArray())
-                .andExpect(jsonPath('$.data', Matchers.hasSize(1)))
         // 応答データ（詳細）
                 .andExpect(jsonPath('$.data[0].id').value(1))
                 .andExpect(jsonPath('$.data[0].email').value("test@sample.com"))
@@ -99,7 +105,7 @@ class UserRestControllerTest extends Specification {
     def "API_TEST_CASE: ユーザ取得（単数）"() {
         setup:
         def userId = 1
-        def resultActions = mvc.perform(get("/api/v1/users/" + userId).contentType(MediaType.APPLICATION_JSON))
+        def resultActions = mvc.perform(get(apiRoot + "/" + userId).contentType(MediaType.APPLICATION_JSON))
         systemOutResponse(resultActions)
         /* Expected Response Data Sample
             {
@@ -130,5 +136,19 @@ class UserRestControllerTest extends Specification {
         // 応答データ（詳細）
                 .andExpect(jsonPath('$.data[0].id').value(1))
                 .andExpect(jsonPath('$.data[0].email').value("test@sample.com"))
+    }
+
+    /**
+     * テストケースごとの後始末
+     */
+    def cleanup() {
+        // no-op
+    }
+
+    /**
+     * テストクラス全体の後始末
+     */
+    def cleanupSpec() {
+        // no-op
     }
 }


### PR DESCRIPTION
取得系APIテストケースのサンプルコードを書いてみました。
更新系APIはDBが汚れないようテスト後にロールバックする方法を考えてからにします。