### PR TITLE
APIの自動テストを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,35 @@ $ cd /path/to/spring-boot-doma2-sample
 $ ./gradlew codegen -PsubSystem=system -Pfunc=client -PfuncStr=取引先 [-Ptarget=dao|dto|repository|service|controller|html]
 ```
 
+## その他
+### IntelliJから自動テストが実行できない
+自動テスト実行時に以下のように表示されて実行できない場合があります
+ ```
+ Command Line is too Long. Shorten command line for your_test or also for JUnit default configuration. 
+```
+
+その場合は以下を試みましょう[（参考）](https://stackoverflow.com/questions/47926382/how-to-configure-shorten-command-line-method-for-whole-project-in-intellij)
+
+以下のファイルをエディタで開く
+```
+/path/to/spring-boot-doma2-sample/.idea/workspace.xml 
+```
+
+以下を
+```xml
+<property name="dynamic.classpath" value="true" />
+```
+
+以下のタグの中に追加する
+
+```xml
+  <component name="PropertiesComponent">
+.
+.
+.
+  </component>
+```
+
 ## 参考
 
 | プロジェクト| 概要|

--- a/sample-domain/src/main/java/com/sample/domain/dto/common/DomaDtoImpl.java
+++ b/sample-domain/src/main/java/com/sample/domain/dto/common/DomaDtoImpl.java
@@ -47,7 +47,6 @@ public abstract class DomaDtoImpl implements DomaDto, Serializable {
     // 楽観的排他制御で使用する改定番号
     @Version
     @Column(name = "version")
-    @JsonIgnore
     Integer version;
 
     // 作成・更新者に使用する値

--- a/sample-web-admin/src/main/java/com/sample/web/admin/controller/api/v1/user/UserRestController.java
+++ b/sample-web-admin/src/main/java/com/sample/web/admin/controller/api/v1/user/UserRestController.java
@@ -5,6 +5,9 @@ import static com.sample.web.base.WebConst.MESSAGE_SUCCESS;
 import java.io.IOException;
 import java.util.Arrays;
 
+import com.sample.domain.DefaultModelMapperFactory;
+import org.modelmapper.Conditions;
+import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.validation.Errors;
@@ -112,7 +115,16 @@ public class UserRestController extends AbstractRestController {
 
         // 1件更新する
         inputUser.setId(userId);
-        User user = userService.update(inputUser);
+        User user;
+        {
+            //TODO 本来ならサービスで実装すべき
+            //created_byなどがAPIからは取得できないので、DBから取得して、パラメータで更新内容を上書きしている
+            user = userService.findById(inputUser.getId());
+            ModelMapper modelMapper = DefaultModelMapperFactory.create();
+            modelMapper.getConfiguration().setPropertyCondition(Conditions.isNotNull());
+            modelMapper.map(inputUser, user);
+        }
+        user = userService.update(user);
 
         Resource resource = resourceFactory.create();
         resource.setData(Arrays.asList(user));

--- a/sample-web-admin/src/test/groovy/com/sample/web/admin/controller/api/v1/user/WhenUseUserApiSpec.groovy
+++ b/sample-web-admin/src/test/groovy/com/sample/web/admin/controller/api/v1/user/WhenUseUserApiSpec.groovy
@@ -1,0 +1,134 @@
+package com.sample.web.admin.controller.api.v1.user
+
+import com.sample.web.admin.test.helper.Doma2TestHelper
+import groovy.json.JsonSlurper
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.MediaType
+import org.springframework.security.test.context.support.WithMockUser
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.transaction.annotation.Transactional
+import org.springframework.web.context.WebApplicationContext
+import spock.lang.Shared
+import spock.lang.Specification
+
+import static org.hamcrest.CoreMatchers.*
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*
+import static org.springframework.test.web.servlet.setup.MockMvcBuilders.webAppContextSetup
+
+@SpringBootTest
+@Transactional // テスト後にロールバックする
+class WhenUseUserApiSpec extends Specification {
+
+
+    @Autowired
+    WebApplicationContext wac
+
+    @Shared
+    MockMvc mvc
+
+    @Autowired
+    Doma2TestHelper h
+
+    def setup() {
+        mvc = webAppContextSetup(wac).apply(springSecurity()).build()
+        h.delete 'users'
+    }
+
+    @WithMockUser(username = "test@sample.com", password = "passw0rd", authorities = ".*")
+    def "ユーザAPIを使うシナリオ"() {
+        given: "ユーザが１件もない状態で"
+        when:
+        def json = ユーザの一覧を取得する()
+        then: "0件であるべき"
+        json == '{"data":[],"message":"正常終了","page":1,"total_pages":1}'
+
+        when:
+        ユーザを追加する(asJson(["first_name": "ichiro"] <<
+                            ["last_name": "suzuki"] <<
+                            ["zip": "1500001"] <<
+                            ["address": "shibuyaku tokyo"] ) )
+        and:
+        json = ユーザの一覧を取得する()
+        then: "追加したユーザが取得できるべき"
+        json.contains('"message":"正常終了"')
+        json.contains('"first_name":"ichiro","last_name":"suzuki"')
+
+        when:
+        def user = 追加したユーザを特定する(json)
+        def id = user['id']
+        def version = user['version']
+        and:
+        json = ユーザを取得する(id)
+        then: "追加したユーザが取得できるべき"
+        json.contains('"message":"正常終了"')
+        json.contains('"first_name":"ichiro","last_name":"suzuki"')
+
+        when:
+        ユーザを更新する(id, asJson(["first_name": "goro"] <<
+                                ["last_name": "yamada"] <<
+                                ["zip": "1500001"] <<
+                                ["address": "shibuyaku tokyo"] <<
+                                ["version": version]))
+        and:
+        json = ユーザを取得する(id)
+        then: "ユーザの情報が更新されているべき"
+        json.contains('"message":"正常終了"')
+        json.contains('"first_name":"goro","last_name":"yamada"')
+
+        when:
+        json = ユーザを削除する(id)
+        and:
+        json = ユーザの一覧を取得する()
+        then: "0件であるべき"
+        json == '{"data":[],"message":"正常終了","page":1,"total_pages":1}'
+    }
+
+    def asJson(map) {
+        def s = map.collect { "\"${it.key}\": \"${it.value}\"" }
+                .inject { s, v -> s + ',' + v }
+        '{' + s + '}'
+    }
+
+    def "ユーザを追加する"(json) {
+        mvc.perform (post("/api/v1/users")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(json))
+            .andExpect(status().isOk())
+            .andExpect(content().string(containsString ('"message":"正常終了"')))
+    }
+
+    def "ユーザの一覧を取得する"(){
+        mvc.perform(get("/api/v1/users" ))
+            .andExpect(status().isOk())
+            .andReturn().response.contentAsString
+    }
+
+    def "追加したユーザを特定する"(jsonAsString) {
+        def jsonSlurper = new JsonSlurper()
+        def json = jsonSlurper.parseText(jsonAsString)
+        json['data'][0]
+    }
+
+    def "ユーザを取得する"(id) {
+        mvc.perform(get("/api/v1/users/${id}"))
+                .andExpect(status().isOk())
+                .andReturn().response.contentAsString
+    }
+
+    def "ユーザを更新する"(id, json) {
+        mvc.perform(put("/api/v1/users/${id}")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(json))
+                .andExpect(status().isOk())
+                .andExpect(content().string(containsString ('"message":"正常終了"')))
+    }
+    def "ユーザを削除する"(id) {
+        mvc.perform(delete("/api/v1/users/${id}"))
+                .andExpect(status().isOk())
+                .andExpect(content().string(containsString ('"message":"正常終了"')))
+    }
+}
+

--- a/sample-web-admin/src/test/groovy/com/sample/web/admin/test/helper/Doma2TestHelper.groovy
+++ b/sample-web-admin/src/test/groovy/com/sample/web/admin/test/helper/Doma2TestHelper.groovy
@@ -1,0 +1,45 @@
+package com.sample.web.admin.test.helper
+
+import org.seasar.doma.jdbc.Config
+import org.seasar.doma.jdbc.builder.DeleteBuilder
+import org.seasar.doma.jdbc.builder.InsertBuilder
+import org.seasar.doma.jdbc.builder.UpdateBuilder
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+
+@Component
+class Doma2TestHelper {
+    @Autowired
+    Config config
+
+    def delete(String table){
+        DeleteBuilder.newInstance(config).sql('delete from ' + toSnakeCase(table)).execute()
+    }
+
+    def insert(String table, Map<String,String> columns){
+        if(columns == null || columns.isEmpty()){
+            return
+        }
+        def c = columns.collect { toSnakeCase(it.key) }
+                .inject {s,k -> s + ',' + k }
+        def v = columns.collect { it.value }
+                .collect {v -> v == null ? 'NULL' : '\'' + v + '\''}
+                .inject {s, v -> s + ',' + v }
+        InsertBuilder.newInstance(config).sql('insert into ' + toSnakeCase(table) + '(' + c + ') VALUES (' + v + ')').execute()
+    }
+
+    def update(String table, Map<String,String> columns, Map<String,String> conditions){
+        if(columns == null || columns.isEmpty()){
+            return
+        }
+        def updated = columns.collect { toSnakeCase(it.key) + '=\'' + it.value + '\''}
+                .inject {s,v -> s + ',' + v }
+        def where = conditions.collect { toSnakeCase(it.key) + '=\'' + it.value + '\''}
+                .inject {s, v -> s + ',' + v }
+        UpdateBuilder.newInstance(config).sql('update ' + toSnakeCase(table) + ' set ' + updated + ' where ' + where).execute()
+    }
+
+    static String toSnakeCase( String text ) {
+        text.replaceAll( /([A-Z])/, /_$1/ ).toLowerCase().replaceAll( /^_/, '' )
+    }
+}


### PR DESCRIPTION
# このプルリクエストをマージすると
* APIの自動テストが追加されます
* 単純なDBの書きかえを行う自動テスト用のヘルパが追加されます
* UserのGET系のAPIでJSONにversionが追加されます
* UserのPUTのAPIで一度DBのユーザを取り直してから更新するようになります
* README に自動テストが動かないときの対処が追加されます

# メッセージ
APIの自動テストがなかったので追加してみました。
また、プロダクションコードの中でテスト中に気になった点を修正してあります

# 注意事項
基本自動テストの追加なのですが、プロダクションコードの以下に手をいれました
* versionがないと更新ができないため、JSONに含めるよう変更
* 更新時にcreated_atがnullのためエラーになるので、Controllerで詰めなおすように変更
