### PR TITLE
flywayでメールテンプレートに変数があった場合にmigrateに失敗する問題の修正

### DIFF
--- a/sample-batch/src/main/resources/application-development.yml
+++ b/sample-batch/src/main/resources/application-development.yml
@@ -19,6 +19,7 @@ spring:
   flyway:
     enabled: true
     baseline-on-migrate: true
+    placeholder-replacement: false
 logging:
   level:
     org.springframework: INFO

--- a/sample-batch/src/main/resources/application-local.yml
+++ b/sample-batch/src/main/resources/application-local.yml
@@ -19,6 +19,7 @@ spring:
     flyway:
         enabled: true
         baseline-on-migrate: true
+        placeholder-replacement: false
 logging:
     level:
         org.springframework: INFO

--- a/sample-web-admin/src/main/resources/application-development.yml
+++ b/sample-web-admin/src/main/resources/application-development.yml
@@ -15,6 +15,7 @@ spring:
   flyway:
     enable: true
     baseline-on-migrate: true
+    placeholder-replacement: false
 doma:
   # SQLファイルをキャッシュしない
   sql-file-repository: no_cache

--- a/sample-web-admin/src/main/resources/application-local.yml
+++ b/sample-web-admin/src/main/resources/application-local.yml
@@ -15,6 +15,7 @@ spring:
   flyway:
     enable: true
     baseline-on-migrate: true
+    placeholder-replacement: false
 doma:
   # SQLファイルをキャッシュしない
   sql-file-repository: no_cache

--- a/sample-web-front/src/main/resources/application-development.yml
+++ b/sample-web-front/src/main/resources/application-development.yml
@@ -15,6 +15,7 @@ spring:
   flyway:
     enable: true
     baseline-on-migrate: true
+    placeholder-replacement: false
 doma:
   # SQLファイルをキャッシュしない
   sql-file-repository: no_cache

--- a/sample-web-front/src/main/resources/application-local.yml
+++ b/sample-web-front/src/main/resources/application-local.yml
@@ -15,6 +15,7 @@ spring:
   flyway:
     enable: true
     baseline-on-migrate: true
+    placeholder-replacement: false
 doma:
   # SQLファイルをキャッシュしない
   sql-file-repository: no_cache


### PR DESCRIPTION
# このプルリクエストをマージすると
* メールのテンプレートに[[${hoge}]]のような変数が入ってもflywayのmigrateで失敗しなくなります