### PR TITLE
二重サブミットのときにオプションを追加

### DIFF
--- a/sample-domain/src/main/java/com/sample/domain/dao/DefaultEntityListener.java
+++ b/sample-domain/src/main/java/com/sample/domain/dao/DefaultEntityListener.java
@@ -27,11 +27,15 @@ public class DefaultEntityListener<ENTITY> implements EntityListener<ENTITY> {
 
     @Override
     public void preInsert(ENTITY entity, PreInsertContext<ENTITY> context) {
-        // 二重送信防止チェック
-        val expected = DoubleSubmitCheckTokenHolder.getExpectedToken();
-        val actual = DoubleSubmitCheckTokenHolder.getActualToken();
 
         if( ! DoubleSubmitCheckTokenHolder.isExcludeCheck()) {
+            if( ! DoubleSubmitCheckTokenHolder.isExistsExpectedTokenKey()){
+                throw new IllegalStateException("指定されたキーが見つかりませんでした。@TokenKeyの設定を確認してください");
+            }
+
+            // 二重送信防止チェック
+            val expected = DoubleSubmitCheckTokenHolder.getExpectedToken();
+            val actual = DoubleSubmitCheckTokenHolder.getActualToken();
             if (expected != null && actual != null && !Objects.equals(expected, actual)) {
                 throw new DoubleSubmitErrorException();
             }

--- a/sample-domain/src/main/java/com/sample/domain/dao/DefaultEntityListener.java
+++ b/sample-domain/src/main/java/com/sample/domain/dao/DefaultEntityListener.java
@@ -31,8 +31,10 @@ public class DefaultEntityListener<ENTITY> implements EntityListener<ENTITY> {
         val expected = DoubleSubmitCheckTokenHolder.getExpectedToken();
         val actual = DoubleSubmitCheckTokenHolder.getActualToken();
 
-        if (expected != null && actual != null && !Objects.equals(expected, actual)) {
-            throw new DoubleSubmitErrorException();
+        if( ! DoubleSubmitCheckTokenHolder.isExcludeCheck()) {
+            if (expected != null && actual != null && !Objects.equals(expected, actual)) {
+                throw new DoubleSubmitErrorException();
+            }
         }
 
         if (entity instanceof DomaDto) {

--- a/sample-domain/src/main/java/com/sample/domain/dao/DoubleSubmitCheckTokenHolder.java
+++ b/sample-domain/src/main/java/com/sample/domain/dao/DoubleSubmitCheckTokenHolder.java
@@ -10,6 +10,7 @@ import java.util.Objects;
 public class DoubleSubmitCheckTokenHolder {
 
     private static final ThreadLocal<DoubleSubmitCheckTokenHolder> HOLDER = new ThreadLocal<>();
+    private String key;
     private String expected;
     private String actual;
     private boolean excludeCheck;
@@ -17,16 +18,27 @@ public class DoubleSubmitCheckTokenHolder {
     /**
      * トークンを保存します。
      *
+     * @param key
      * @param expected
      * @param actual
      * @aparam excludeCheck
      */
-    public static void set(String expected, String actual, boolean excludeCheck) {
+    public static void set(String key, String expected, String actual, boolean excludeCheck) {
         val me = new DoubleSubmitCheckTokenHolder();
+        me.key = key;
         me.expected = expected;
         me.actual = actual;
         me.excludeCheck = excludeCheck;
         HOLDER.set(me);
+    }
+
+    /**
+     * トークンのキーを返します。
+     *
+     * @return
+     */
+    public static String getTokenKey() {
+        return me().key;
     }
 
     /**

--- a/sample-domain/src/main/java/com/sample/domain/dao/DoubleSubmitCheckTokenHolder.java
+++ b/sample-domain/src/main/java/com/sample/domain/dao/DoubleSubmitCheckTokenHolder.java
@@ -12,17 +12,20 @@ public class DoubleSubmitCheckTokenHolder {
     private static final ThreadLocal<DoubleSubmitCheckTokenHolder> HOLDER = new ThreadLocal<>();
     private String expected;
     private String actual;
+    private boolean excludeCheck;
 
     /**
      * トークンを保存します。
      *
      * @param expected
      * @param actual
+     * @aparam excludeCheck
      */
-    public static void set(String expected, String actual) {
+    public static void set(String expected, String actual, boolean excludeCheck) {
         val me = new DoubleSubmitCheckTokenHolder();
         me.expected = expected;
         me.actual = actual;
+        me.excludeCheck = excludeCheck;
         HOLDER.set(me);
     }
 
@@ -42,6 +45,15 @@ public class DoubleSubmitCheckTokenHolder {
      */
     public static String getActualToken() {
         return me().actual;
+    }
+
+    /**
+     * トークンチェックの対象から除外するかを返します。
+     *
+     * @return
+     */
+    public static boolean isExcludeCheck() {
+        return me().excludeCheck;
     }
 
     /**

--- a/sample-domain/src/main/java/com/sample/domain/dao/DoubleSubmitCheckTokenHolder.java
+++ b/sample-domain/src/main/java/com/sample/domain/dao/DoubleSubmitCheckTokenHolder.java
@@ -1,13 +1,17 @@
 package com.sample.domain.dao;
 
+import lombok.val;
+
+import java.util.Objects;
+
 /**
  * 二重送信防止チェックトークンホルダー
  */
 public class DoubleSubmitCheckTokenHolder {
 
-    private static final ThreadLocal<String> EXPECTED_TOKEN = new ThreadLocal<>();
-
-    private static final ThreadLocal<String> ACTUAL_TOKEN = new ThreadLocal<>();
+    private static final ThreadLocal<DoubleSubmitCheckTokenHolder> HOLDER = new ThreadLocal<>();
+    private String expected;
+    private String actual;
 
     /**
      * トークンを保存します。
@@ -16,8 +20,10 @@ public class DoubleSubmitCheckTokenHolder {
      * @param actual
      */
     public static void set(String expected, String actual) {
-        EXPECTED_TOKEN.set(expected);
-        ACTUAL_TOKEN.set(actual);
+        val me = new DoubleSubmitCheckTokenHolder();
+        me.expected = expected;
+        me.actual = actual;
+        HOLDER.set(me);
     }
 
     /**
@@ -26,7 +32,7 @@ public class DoubleSubmitCheckTokenHolder {
      * @return
      */
     public static String getExpectedToken() {
-        return EXPECTED_TOKEN.get();
+        return me().expected;
     }
 
     /**
@@ -35,14 +41,20 @@ public class DoubleSubmitCheckTokenHolder {
      * @return
      */
     public static String getActualToken() {
-        return ACTUAL_TOKEN.get();
+        return me().actual;
     }
 
     /**
      * 監査情報をクリアします。
      */
     public static void clear() {
-        EXPECTED_TOKEN.remove();
-        ACTUAL_TOKEN.remove();
+        HOLDER.remove();
+    }
+
+    private static DoubleSubmitCheckTokenHolder me(){
+        if( Objects.isNull(HOLDER.get()) ){
+            return new DoubleSubmitCheckTokenHolder();
+        }
+        return HOLDER.get();
     }
 }

--- a/sample-domain/src/main/java/com/sample/domain/dao/DoubleSubmitCheckTokenHolder.java
+++ b/sample-domain/src/main/java/com/sample/domain/dao/DoubleSubmitCheckTokenHolder.java
@@ -13,6 +13,7 @@ public class DoubleSubmitCheckTokenHolder {
     private String key;
     private String expected;
     private String actual;
+    private boolean existsExpectedTokenKey;
     private boolean excludeCheck;
 
     /**
@@ -21,13 +22,15 @@ public class DoubleSubmitCheckTokenHolder {
      * @param key
      * @param expected
      * @param actual
+     * @param existsExpectedTokenKey
      * @aparam excludeCheck
      */
-    public static void set(String key, String expected, String actual, boolean excludeCheck) {
+    public static void set(String key, String expected, String actual, boolean existsExpectedTokenKey, boolean excludeCheck) {
         val me = new DoubleSubmitCheckTokenHolder();
         me.key = key;
         me.expected = expected;
         me.actual = actual;
+        me.existsExpectedTokenKey = existsExpectedTokenKey;
         me.excludeCheck = excludeCheck;
         HOLDER.set(me);
     }
@@ -57,6 +60,15 @@ public class DoubleSubmitCheckTokenHolder {
      */
     public static String getActualToken() {
         return me().actual;
+    }
+
+    /**
+     * セッション中にトークンキーがあるかを返します
+     *
+     * @return
+     */
+    public static boolean isExistsExpectedTokenKey(){
+        return me().existsExpectedTokenKey;
     }
 
     /**

--- a/sample-web-base/src/main/java/com/sample/web/base/aop/SetDoubleSubmitCheckTokenInterceptor.java
+++ b/sample-web-base/src/main/java/com/sample/web/base/aop/SetDoubleSubmitCheckTokenInterceptor.java
@@ -1,10 +1,12 @@
 package com.sample.web.base.aop;
 
 import java.util.Objects;
+import java.util.Optional;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import com.sample.web.base.security.annotation.TokenKey;
 import com.sample.web.base.security.annotation.ExcludeCheckToken;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.web.method.HandlerMethod;
@@ -26,10 +28,11 @@ public class SetDoubleSubmitCheckTokenInterceptor extends BaseHandlerInterceptor
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler)
             throws Exception {
         // コントローラーの動作前
-        val excludeCheck = excludeCheckToken(handler);
-        val expected = DoubleSubmitCheckToken.getExpectedToken(request);
+        val key = takeOutTokenKey(handler).orElse(null);
+        val expected = DoubleSubmitCheckToken.getExpectedToken(request, key);
         val actual = DoubleSubmitCheckToken.getActualToken(request);
-        DoubleSubmitCheckTokenHolder.set(expected, actual, excludeCheck);
+        val excludeCheck = excludeCheckToken(handler);
+        DoubleSubmitCheckTokenHolder.set(key, expected, actual, excludeCheck);
         return true;
     }
 
@@ -42,11 +45,12 @@ public class SetDoubleSubmitCheckTokenInterceptor extends BaseHandlerInterceptor
                 return;
             }
             // POSTされたときにトークンが一致していれば新たなトークンを発行する
-            val expected = DoubleSubmitCheckToken.getExpectedToken(request);
+            val key = DoubleSubmitCheckTokenHolder.getTokenKey();
+            val expected = DoubleSubmitCheckToken.getExpectedToken(request, key);
             val actual = DoubleSubmitCheckToken.getActualToken(request);
 
             if (expected != null && actual != null && Objects.equals(expected, actual)) {
-                DoubleSubmitCheckToken.renewToken(request);
+                DoubleSubmitCheckToken.renewToken(request, key);
             }
         }
     }
@@ -69,4 +73,19 @@ public class SetDoubleSubmitCheckTokenInterceptor extends BaseHandlerInterceptor
         // 処理完了後
         DoubleSubmitCheckTokenHolder.clear();
     }
+
+    Optional<String> takeOutTokenKey(Object handler) {
+        if (!(handler instanceof HandlerMethod)) {
+            return Optional.empty();
+        }
+        val hm = (HandlerMethod)handler;
+        if(hm.getMethod().isAnnotationPresent(TokenKey.class)){
+            return Optional.of(hm.getMethod().getAnnotation(TokenKey.class).value());
+        }
+        if(hm.getBeanType().isAnnotationPresent(TokenKey.class)){
+            return Optional.of(hm.getBeanType().getAnnotation(TokenKey.class).value());
+        }
+        return Optional.empty();
+    }
+
 }

--- a/sample-web-base/src/main/java/com/sample/web/base/aop/SetDoubleSubmitCheckTokenInterceptor.java
+++ b/sample-web-base/src/main/java/com/sample/web/base/aop/SetDoubleSubmitCheckTokenInterceptor.java
@@ -31,8 +31,9 @@ public class SetDoubleSubmitCheckTokenInterceptor extends BaseHandlerInterceptor
         val key = takeOutTokenKey(handler).orElse(null);
         val expected = DoubleSubmitCheckToken.getExpectedToken(request, key);
         val actual = DoubleSubmitCheckToken.getActualToken(request);
+        val existsExpectedTokenKey = DoubleSubmitCheckToken.isExistsExpectedTokenKey(request, key);
         val excludeCheck = excludeCheckToken(handler);
-        DoubleSubmitCheckTokenHolder.set(key, expected, actual, excludeCheck);
+        DoubleSubmitCheckTokenHolder.set(key, expected, actual, existsExpectedTokenKey, excludeCheck);
         return true;
     }
 
@@ -44,6 +45,11 @@ public class SetDoubleSubmitCheckTokenInterceptor extends BaseHandlerInterceptor
             if(DoubleSubmitCheckTokenHolder.isExcludeCheck()){
                 return;
             }
+
+            if( ! DoubleSubmitCheckTokenHolder.isExistsExpectedTokenKey()){
+                throw new IllegalStateException("指定されたキーが見つかりませんでした。@TokenKeyの設定を確認してください");
+            }
+
             // POSTされたときにトークンが一致していれば新たなトークンを発行する
             val key = DoubleSubmitCheckTokenHolder.getTokenKey();
             val expected = DoubleSubmitCheckToken.getExpectedToken(request, key);

--- a/sample-web-base/src/main/java/com/sample/web/base/security/DoubleSubmitCheckToken.java
+++ b/sample-web-base/src/main/java/com/sample/web/base/security/DoubleSubmitCheckToken.java
@@ -58,8 +58,11 @@ public class DoubleSubmitCheckToken {
      *
      * @param request
      * @return expected token
+     * @Deprecated @link{com.sample.web.base.security.DoubleSubmitCheckToken#getExpectedToken(HttpServletRequest, String)}を使ってください
+     *
      */
     @SuppressWarnings("unchecked")
+    @Deprecated
     public static String getExpectedToken(HttpServletRequest request) {
         return getExpectedToken(request, null);
     }

--- a/sample-web-base/src/main/java/com/sample/web/base/security/DoubleSubmitCheckToken.java
+++ b/sample-web-base/src/main/java/com/sample/web/base/security/DoubleSubmitCheckToken.java
@@ -9,6 +9,8 @@ import com.sample.web.base.util.SessionUtils;
 
 import lombok.val;
 
+import java.util.Objects;
+
 public class DoubleSubmitCheckToken {
 
     public static final String DOUBLE_SUBMIT_CHECK_PARAMETER = "_double";
@@ -125,6 +127,22 @@ public class DoubleSubmitCheckToken {
         }
 
         return map;
+    }
+
+    public static boolean isExistsExpectedTokenKey(HttpServletRequest request, String key){
+        //キーが指定されている場合は、キーがSession中のMapにあることを保証する
+        if(Objects.isNull(key) || ! hasTokenInSession(request)) {
+            return true;
+        }
+        LRUMap map = getLRUMap(request);
+        if( map.containsKey(key) ){
+            return true;
+        }
+        return false;
+    }
+
+    protected static boolean hasTokenInSession(HttpServletRequest request) {
+        return Objects.nonNull(SessionUtils.getAttribute(request, DOUBLE_SUBMIT_CHECK_CONTEXT));
     }
 
     /**

--- a/sample-web-base/src/main/java/com/sample/web/base/security/DoubleSubmitCheckingRequestDataValueProcessor.java
+++ b/sample-web-base/src/main/java/com/sample/web/base/security/DoubleSubmitCheckingRequestDataValueProcessor.java
@@ -1,9 +1,11 @@
 package com.sample.web.base.security;
 
 import java.util.Map;
+import java.util.Objects;
 
 import javax.servlet.http.HttpServletRequest;
 
+import com.sample.domain.dao.DoubleSubmitCheckTokenHolder;
 import org.springframework.security.web.servlet.support.csrf.CsrfRequestDataValueProcessor;
 import org.springframework.web.servlet.support.RequestDataValueProcessor;
 
@@ -34,11 +36,14 @@ public class DoubleSubmitCheckingRequestDataValueProcessor implements RequestDat
         val map = PROCESSOR.getExtraHiddenFields(request);
 
         if (!map.isEmpty()) {
-            val action = ACTION_HOLDER.get();
-            String token = DoubleSubmitCheckToken.getExpectedToken(request, action);
+            String key = DoubleSubmitCheckTokenHolder.getTokenKey();
+            if(Objects.isNull(key)) {
+                key = ACTION_HOLDER.get();
+            }
+            String token = DoubleSubmitCheckToken.getExpectedToken(request, key);
 
             if (Objects.isNull(token)) {
-                token = DoubleSubmitCheckToken.renewToken(request, action);
+                token = DoubleSubmitCheckToken.renewToken(request, key);
             }
 
             map.put(DoubleSubmitCheckToken.DOUBLE_SUBMIT_CHECK_PARAMETER, token);

--- a/sample-web-base/src/main/java/com/sample/web/base/security/DoubleSubmitCheckingRequestDataValueProcessor.java
+++ b/sample-web-base/src/main/java/com/sample/web/base/security/DoubleSubmitCheckingRequestDataValueProcessor.java
@@ -37,7 +37,7 @@ public class DoubleSubmitCheckingRequestDataValueProcessor implements RequestDat
             val action = ACTION_HOLDER.get();
             String token = DoubleSubmitCheckToken.getExpectedToken(request, action);
 
-            if (token == null) {
+            if (Objects.isNull(token)) {
                 token = DoubleSubmitCheckToken.renewToken(request, action);
             }
 

--- a/sample-web-base/src/main/java/com/sample/web/base/security/annotation/ExcludeCheckToken.java
+++ b/sample-web-base/src/main/java/com/sample/web/base/security/annotation/ExcludeCheckToken.java
@@ -1,0 +1,14 @@
+package com.sample.web.base.security.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * このアノテーションは二重送信時のトークンチェックを行わないことをあらわすアノテーションです
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD})
+public @interface ExcludeCheckToken {
+}

--- a/sample-web-base/src/main/java/com/sample/web/base/security/annotation/TokenKey.java
+++ b/sample-web-base/src/main/java/com/sample/web/base/security/annotation/TokenKey.java
@@ -1,0 +1,15 @@
+package com.sample.web.base.security.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * このアノテーションは二重送信時のトークンのキーをあらわすアノテーションです
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD})
+public @interface TokenKey {
+    String value();
+}


### PR DESCRIPTION
# はじめに
* 現状、POST時の二重サブミットのチェックはトークンを仕込んだ画面を表示するアクションとPOSTのアクションのURLが一致しないと想定どおりにチェックが働かない

# このプルリクエストをマージすると
* クラスやメソッドに二重サブミットのチェックを行わないことを明示的に指定できるようになります
* クラスやメソッドにトークンを保持するキー名を明示的に指定できるようになります

# 使い方
## @ExcludeCheckToken
二重サブミットのチェックを行わないことを明示的に指定する場合に使用します

e.g.
```java
@Controller
@ExcludeCheckToken //クラスに指定した場合はそのコントローラのアクションすべてで二重サブミットのチェックを行わないようになります
public class HogeContoroller{
    @PostMapping("/new")
    @ExcludeCheckToken //メソッドに指定した場合はそのアクションで二重サブミットのチェックを行わないようになります

    public String save(HogeForm form){ /* snip */}
}
```


## @ TokenKey
トークンを保持するキー名を明示的に指定する際に使用します

e.g.
```java
@Controller
@TokenKey("hoge") //クラスに指定した場合はそのコントローラのアクションすべてでトークンを保持するキーとして利用されます
public class HogeContoroller{
    @GetMapping("/new/show")
    @TokenKey("fuga") //メソッドに指定した場合はそのアクションでトークンを保持するキーとして利用されます
                 //POSTするアクションとその画面のURLが異なる場合に利用します。キーの値は画面表示とPOSTのアクションで同じ値を指定してください
    public String showNew(){ /* snip */}

    @PostMapping("/new")
    @TokenKey("fuga") 
    public String save(HogeForm form){ /* snip */}
}
```
# 注意事項
* キー名を指定した場合は、そのキーがセッション中にあることを保証します。（ない場合はトークンチェックのタイミングで例外が発生します）
* 上記はチェックするアクションでセッションが新規になる場合は発生しません（その前にログインページに遷移すると思いますが念のため）
* サンプルアプリのリファレンス実装として適切でない場合はそっとプルリクエストをクローズしてください