### PR TITLE
ユーザを新規に作ったときにそのユーザでログインできない問題の対応

### DIFF
--- a/sample-domain/src/main/java/com/sample/domain/repository/users/UserRepository.java
+++ b/sample-domain/src/main/java/com/sample/domain/repository/users/UserRepository.java
@@ -91,7 +91,7 @@ public class UserRepository extends BaseRepository {
         // 役割権限紐付けを登録する
         val userRole = new UserRole();
         userRole.setUserId(inputUser.getId());
-        userRole.setRoleKey("users");
+        userRole.setRoleKey("user");
         userRoleDao.insert(userRole);
 
         return inputUser;


### PR DESCRIPTION
# このプルリクエストをマージすると
管理側で新規に作ったユーザで、フロント側にログインするとログインできない問題が解消します

# 原因
* ユーザ作成時に一緒に作られるUSER_ROLEのROLE_KEYに誤りがあった

# 注意事項
*特になし